### PR TITLE
Replace Deprecated np.float with np.float64 in nd2reader

### DIFF
--- a/nd2reader/raw_metadata.py
+++ b/nd2reader/raw_metadata.py
@@ -293,9 +293,9 @@ class RawMetadata(object):
             roi_dict = self._parse_vect_anim(roi_dict, raw_roi_dict[six.b('m_vectAnimParams_%d' % i)])
 
         # convert to NumPy arrays
-        roi_dict["timepoints"] = np.array(roi_dict["timepoints"], dtype=np.float)
-        roi_dict["positions"] = np.array(roi_dict["positions"], dtype=np.float)
-        roi_dict["sizes"] = np.array(roi_dict["sizes"], dtype=np.float)
+        roi_dict["timepoints"] = np.array(roi_dict["timepoints"], dtype=np.float64)
+        roi_dict["positions"] = np.array(roi_dict["positions"], dtype=np.float64)
+        roi_dict["sizes"] = np.array(roi_dict["sizes"], dtype=np.float64)
 
         return roi_dict
 

--- a/nd2reader/reader.py
+++ b/nd2reader/reader.py
@@ -227,7 +227,7 @@ class ND2Reader(FramesSequenceND):
             return self._timesteps
 
         self._timesteps = (
-            np.array(list(self._parser._raw_metadata.acquisition_times), dtype=np.float)
+            np.array(list(self._parser._raw_metadata.acquisition_times), dtype=np.float64)
             * 1000.0
         )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy>=1.14
+numpy>=1.20
 six>=1.4
 xmltodict>=0.9.2
 pims>=0.3.0


### PR DESCRIPTION
## Overview
This PR addresses the issue where `np.float` causes an attribute error in the nd2reader package. The error is due to the deprecation of `np.float` in newer versions of NumPy.

## Changes
- Replaced all instances of `np.float` with `np.float64`.

## Related Issues
#69 #67 

## Notes
- The change adheres to the recommendations found in the NumPy 1.20 release notes regarding the deprecation of `np.float`.